### PR TITLE
Add .coffee.md as valid extension

### DIFF
--- a/literate-coffee-mode.el
+++ b/literate-coffee-mode.el
@@ -129,5 +129,6 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.litcoffee\\'" . litcoffee-mode))
+(add-to-list 'auto-mode-alist '("\\.coffee.md\\'" . litcoffee-mode))
 
 ;;; literate-coffee-mode.el ends here


### PR DESCRIPTION
Consider .coffee.md as valid extension for litcoffee-mode, besides .litcoffee.
